### PR TITLE
Limit string length on input box

### DIFF
--- a/src/databaseCreator.ts
+++ b/src/databaseCreator.ts
@@ -162,7 +162,7 @@ export class DatabaseCreator {
 
     private async runCreateDatabaseQuery(dbName: string, queryProvider: sqlops.QueryProvider, tempUri: string) {
         let query = `BEGIN TRY
-    CREATE DATABASE [${dbName}]
+    CREATE DATABASE [${dbName.replace(/]/g , "]]")}]
     SELECT 1 AS NoError
 END TRY
 BEGIN CATCH

--- a/src/databaseCreator.ts
+++ b/src/databaseCreator.ts
@@ -58,7 +58,7 @@ export class DatabaseCreator {
         }
 
         // Prompt the user for a new database name
-        let dbName = await vscode.window.showInputBox({ prompt: 'Enter database name', });
+        let dbName = await vscode.window.showInputBox({ prompt: 'Enter database name', validateInput: (value) => value && value.length > 124 ? 'Must be 124 chars or less' : undefined});
         if (!dbName) {
             return;
         }


### PR DESCRIPTION
Limit the database name to 124 characters

The engine limit is 128, but unless you specify a logical log name, it appends _log, reducing the limit to 124. 